### PR TITLE
Fix negative influence sign error

### DIFF
--- a/BiasNET_Python.py
+++ b/BiasNET_Python.py
@@ -46,8 +46,8 @@ class PolarizationSimulation:
         new_beliefs = self.beliefs.copy()
 
         #declare influence of positive and negative beliefs for affinity with other agents
-        positive_influence_rate = 0.05
-        negative_influence_rate = -0.03
+        positive_influence_rate = 0.005
+        negative_influence_rate = -0.003
         
         for agent in range(self.num_agents):
             for issue in range(self.num_issues):
@@ -168,7 +168,7 @@ class PolarizationSimulation:
         belief_distance_line, = ax_polarization.plot([], [], lw=2, linestyle='--', color='green', 
                                                    label='Avg. Belief Distance')
         ax_polarization.set_xlim(0, self.max_steps)
-        ax_polarization.set_ylim(0, 2)  # Adjusted for both metrics
+        ax_polarization.set_ylim(0, 3)  # Adjusted for both metrics
         ax_polarization.set_xlabel('Step')
         ax_polarization.set_ylabel('Polarization Metrics')
         ax_polarization.set_title('Polarization Over Time')

--- a/BiasNET_Python.py
+++ b/BiasNET_Python.py
@@ -68,7 +68,7 @@ class PolarizationSimulation:
                             # Push away from the other agent's belief
                             influence = negative_influence_rate * self.affinity[agent, other_agent] * \
                                       (self.beliefs[other_agent, issue] - self.beliefs[agent, issue])
-                            social_influence += influence
+                            social_influence -= influence
                 
                 # Apply social influence
                 new_beliefs[agent, issue] += social_influence

--- a/BiasNET_Streamlit.py
+++ b/BiasNET_Streamlit.py
@@ -70,7 +70,7 @@ class PolarizationSimulation:
                             # Push away from the other agent's belief - using negative influence rate directly
                             influence = self.negative_influence_rate * self.affinity[agent, other_agent] * \
                                       (self.beliefs[other_agent, issue] - self.beliefs[agent, issue])
-                            social_influence += influence
+                            social_influence -= influence
                 
                 # Apply social influence
                 new_beliefs[agent, issue] += social_influence

--- a/BiasNET_Streamlit.py
+++ b/BiasNET_Streamlit.py
@@ -200,7 +200,7 @@ class PolarizationSimulation:
         ax_polarization.plot(self.belief_distance_history, lw=2, linestyle='--', 
                            color='green', label='Avg. Belief Distance')
         ax_polarization.set_xlim(0, self.max_steps)
-        ax_polarization.set_ylim(0, 2)  # Adjusted for both metrics
+        ax_polarization.set_ylim(0, 3)  # Adjusted for both metrics
         ax_polarization.set_xlabel('Step')
         ax_polarization.set_ylabel('Polarization Metrics')
         ax_polarization.set_title('Polarization Over Time')
@@ -254,9 +254,9 @@ def main():
                              help="Number of issues that agents have beliefs about")
         affinity_change_rate = st.slider("Affinity change rate", 0.01, 0.2, 0.05, 0.01, 
                                        help="Scaling factor for affinity updates")
-        positive_influence_rate = st.slider("Positive influence strength", 0.01, 0.2, 0.05, 0.01, 
+        positive_influence_rate = st.slider("Positive influence strength", 0.001, 0.02, 0.005, 0.001,
                                           help="Strength of positive influence")
-        negative_influence_rate = st.slider("Negative influence strength", -0.2, -0.01, -0.03, 0.01, 
+        negative_influence_rate = st.slider("Negative influence strength", -0.02, -0.001, -0.003, 0.001,
                                           help="Strength of negative influence (negative value)")
         max_steps = st.slider("Maximum simulation steps", 100, 1000, 500, 50)
         step_increment = st.slider("Steps per update", 1, 20, 5, 


### PR DESCRIPTION
This fixes the issue but creates some other issues that I also addressed

1. The avg. belief distance goes up over time and quickly goes outside of the bounds of the graph. I've adjusted the graph bounds to be able to contain typical values.
2. Polarization happens extremely quickly. Not an issue per se, but I lowered the default values to be at a less aggressive pace.

I'm not familiar with streamlit, so I have not tested those changes.